### PR TITLE
Add error handling for exceeding max sequence number, and refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,16 @@ test_unit:
 
 # Test examples
 test_build_basic:
-	cd examples/basic/
-	go test -c -o test_build_basic ./...
-	./test_build_basic
-	rm test_build_basic
+	go build -o ./example-basic ./examples/basic/main.go
+	rm example-basic
 
 test_build_server:
-	cd examples/server/
-	go test -c -o test_build_server ./...
-	./test_build_server
-	rm test_build_server
+	cd examples/server && \
+	go build -o ./example-server ./main.go
+	rm examples/server/example-server
+
+# Run Examples
+run_example_basic:
+	go run examples/basic/main.go
+run_example_server:
+	go run examples/server/main.go

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Structure of ID:
 
 - 0: Placeholder, could indicate the sign, remain for future use.
 - timestamp: unix timestamp in milliseconds. The default epoch is on 2025-01-01T00:00.000Z. 41 bit could have total of 2^41 = 2.2 Trillion milliseconds ~= 69.8 years. Max date could reach year 2095.
-- dataCenterID: max 32 data center
-- machineId: max 32 machine (nodes) in 1 data center
-- sequenceNUmber: max 4096 sequence number per millisecond
+- dataCenterID: 5 bits, max 32 data center (0 - 31)
+- machineId: 5 bits, max 32 machine (nodes) in 1 data center (0 - 31)
+- sequenceNUmber: 12 bits, max 4096 sequence number per millisecond (0 - 4095)
 
 Example generated ID:
 (DataCenterID: 13, MachineID: 14, Epoch: DefaultEpoch)
@@ -51,8 +51,14 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	id1 := s.GenerateId()
-	id2 := s.GenerateId()
+	id1, err := s.GenerateId()
+	if err != nil {
+		panic(err)
+	}
+	id2, err := s.GenerateId()
+	if err != nil {
+		panic(err)
+	}
 
 	// ID 1
 	fmt.Printf("ID: %s\n", id1.String())                // output, eg. 37866498659848192

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -1,5 +1,0 @@
-module example
-
-go 1.24.0
-
-require github.com/ckng0221/snowid v0.0.0-20250415120130-8e49a66aa5b2

--- a/examples/basic/go.sum
+++ b/examples/basic/go.sum
@@ -1,2 +1,0 @@
-github.com/ckng0221/snowid v0.0.0-20250415120130-8e49a66aa5b2 h1:cJY6CySMJcwRmyb3FpXMtv3OaffJQGlO0UOgu2swYaw=
-github.com/ckng0221/snowid v0.0.0-20250415120130-8e49a66aa5b2/go.mod h1:q9lfy4ZleBmNBT+xrVmNAUw9hw/NoBibIlF7RlQMQGQ=

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -14,8 +14,14 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	id1 := s.GenerateId()
-	id2 := s.GenerateId()
+	id1, err := s.GenerateId()
+	if err != nil {
+		panic(err)
+	}
+	id2, err := s.GenerateId()
+	if err != nil {
+		panic(err)
+	}
 
 	// ID 1
 	fmt.Printf("ID: %s\n", id1.String())                // output, eg. 37866498659848192

--- a/examples/server/go.mod
+++ b/examples/server/go.mod
@@ -3,6 +3,8 @@ module example
 go 1.24.0
 
 require (
-	github.com/ckng0221/snowid v0.0.0-20250415120130-8e49a66aa5b2
+	github.com/ckng0221/snowid v0.0.0-00010101000000-000000000000
 	github.com/joho/godotenv v1.5.1
 )
+
+replace github.com/ckng0221/snowid => ../..

--- a/examples/server/go.sum
+++ b/examples/server/go.sum
@@ -1,4 +1,2 @@
-github.com/ckng0221/snowid v0.0.0-20250415120130-8e49a66aa5b2 h1:cJY6CySMJcwRmyb3FpXMtv3OaffJQGlO0UOgu2swYaw=
-github.com/ckng0221/snowid v0.0.0-20250415120130-8e49a66aa5b2/go.mod h1:q9lfy4ZleBmNBT+xrVmNAUw9hw/NoBibIlF7RlQMQGQ=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -44,8 +44,18 @@ func main() {
 	})
 
 	http.HandleFunc("POST /ids", func(w http.ResponseWriter, r *http.Request) {
-		id := s.GenerateId()
-		log.Println("id", id.String())
+		id, err := s.GenerateId()
+		if err != nil {
+			log.Print(err.Error())
+			errMsg := "Internal server error"
+			res := map[string]any{
+				"status": 500,
+				"error":  errMsg,
+			}
+			json.NewEncoder(w).Encode(res)
+			return
+		}
+		log.Println("ID", id.String())
 		w.Header().Set("Content-Type", "application/json")
 		res := map[string]any{
 			"status": 200,

--- a/snowid_test.go
+++ b/snowid_test.go
@@ -206,7 +206,15 @@ func TestGenerateExceedSequenceLimitIdCountWithSleep(t *testing.T) {
 		id, _ := s.GenerateId()
 		ids = append(ids, id)
 	}
+	// check total
 	if len(ids) != 2*SEQUENCE_CAP {
 		t.Errorf("Expected quantity %d, got %d", 2*SEQUENCE_CAP, len(ids))
 	}
+
+	// check length
+	last := ids[len(ids)-1]
+	if len(last.StringBinary()) > TOTAL_BIT {
+		t.Errorf("Expected length %d, got %d", TOTAL_BIT, len(last.StringBinary()))
+	}
+
 }


### PR DESCRIPTION
Changes include:
- Add error handling when there is more than 4096 sequence number generated.
- Update examples dependencies. Remove go.mod reference for basic, replace path for server. To keep the examples always reference to the latest module.
- Refactor and fix codes.