### PR TITLE
Add int64 method and fix bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test_all: test_unit test_build_basic test_build_server
 
 test_unit:
-	go test ./...
+	go test ./... -count=1
 
 # Test examples
 test_build_basic:

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -24,16 +24,18 @@ func main() {
 	}
 
 	// ID 1
-	fmt.Printf("ID: %s\n", id1.String())                // output, eg. 37866498659848192
-	fmt.Printf("ID (Binary): %s\n", id1.StringBinary()) // output, eg. 0000000010000110100001110110000101000001100000100001000000000000
+	fmt.Printf("ID (string): %s\n", id1.String())       // output, eg. "37866498659848192"
+	fmt.Printf("ID (Binary): %s\n", id1.StringBinary()) // output, eg. "0000000010000110100001110110000101000001100000100001000000000000"
+	fmt.Printf("ID (Decimal): %d\n", id1.Int64())       // output, eg. 37866498659848192
 	fmt.Printf("Sequence: %d\n", id1.SequenceNumber)    // sequence 0
 	// ID 2
-	fmt.Printf("ID: %s\n", id2.String())                // outpuot, eg. 37866498659848193
-	fmt.Printf("ID (Binary): %s\n", id2.StringBinary()) // output, eg. 0000000010000110100001110110000101000001100000100001000000000001
+	fmt.Printf("ID: %s\n", id2.String())                // outpuot, eg. "37866498659848193"
+	fmt.Printf("ID (Binary): %s\n", id2.StringBinary()) // output, eg. "0000000010000110100001110110000101000001100000100001000000000001"
+	fmt.Printf("ID (Decimal): %d\n", id2.Int64())       // output, eg. 37866498659848192
 	fmt.Printf("Sequence: %d\n", id2.SequenceNumber)    // sequence 1
 
 	// Parse ID
 	id1Copy := id1.String()
 	reverseParseId1, _ := snowid.ParseId(id1Copy, snowid.DefaultEpoch)
-	fmt.Printf("ID: %s\n", reverseParseId1.String()) // same id as ID 1 after parsing, ie. 37866498659848192
+	fmt.Printf("ID: %s\n", reverseParseId1.String()) // same id as ID 1 after parsing, ie. "37866498659848192"
 }

--- a/snowid.go
+++ b/snowid.go
@@ -142,7 +142,7 @@ func (s *SnowIdGenerator) ResetRecords() {
 	s.l.Unlock()
 }
 
-// Return binary string
+// Return binary string of ID
 func (id *SnowID) StringBinary() string {
 	timestamp_bin := fmt.Sprintf("%041b", id.Timestamp)
 	dataCenterId_bin := fmt.Sprintf("%05b", id.DataCenterId)
@@ -152,9 +152,15 @@ func (id *SnowID) StringBinary() string {
 	return fmt.Sprintf("%s%s%s%s%s", DEFAULT_PLACEHOLDER_BIT, timestamp_bin, dataCenterId_bin, machineId_bin, sequenceNumber_bin)
 }
 
-func (id *SnowID) String() string {
+// return decimal integer of ID
+func (id *SnowID) Int64() int64 {
 	id_int, _ := strconv.ParseInt(id.StringBinary(), 2, 64)
-	return fmt.Sprint(id_int)
+	return id_int
+}
+
+// Return decimal string of ID
+func (id *SnowID) String() string {
+	return strconv.FormatInt(id.Int64(), 10)
 }
 
 func (id *SnowID) Datetime() time.Time {

--- a/snowid_test.go
+++ b/snowid_test.go
@@ -17,8 +17,13 @@ func TestCustomEpochDateTimeDefaultEpoch(t *testing.T) {
 	s, err := NewSnowIdGenerator(machineId, dataCenterId, DefaultEpoch)
 	if err != nil {
 		t.Error(err.Error())
+		return
 	}
-	id, _ := s.GenerateId()
+	id, err := s.GenerateId()
+	if err != nil {
+		t.Errorf("Failed to generate ID: %s", err.Error())
+		return
+	}
 	id_date := id.Datetime().UTC().String()[:10]
 	expectedDate := time.Now().UTC().String()[:10]
 
@@ -33,8 +38,13 @@ func TestCustomEpochDateTimeEarlierEpoch(t *testing.T) {
 	s, err := NewSnowIdGenerator(machineId, dataCenterId, earlierEpoch)
 	if err != nil {
 		t.Error(err.Error())
+		return
 	}
-	id, _ := s.GenerateId()
+	id, err := s.GenerateId()
+	if err != nil {
+		t.Errorf("Failed to generate ID: %s", err.Error())
+		return
+	}
 	id_date := id.Datetime().UTC().String()[:10]
 	expectedDate := time.Now().UTC().String()[:10]
 
@@ -50,7 +60,11 @@ func TestCustomEpochDateTimeUnixEpoch(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	id, _ := s.GenerateId()
+	id, err := s.GenerateId()
+	if err != nil {
+		t.Errorf("Failed to generate ID: %s", err.Error())
+		return
+	}
 	id_date := id.Datetime().UTC().String()[:10]
 	expectedDate := time.Now().UTC().String()[:10]
 
@@ -183,7 +197,11 @@ func TestGenerateMany(t *testing.T) {
 	qty := 1000
 	ids := []*SnowID{}
 	for range qty {
-		id, _ := s.GenerateId()
+		id, err := s.GenerateId()
+		if err != nil {
+			t.Errorf("Failed to generate ID: %s", err.Error())
+			return
+		}
 		ids = append(ids, id)
 	}
 	if len(ids) != qty {
@@ -211,9 +229,12 @@ func TestGenerateExceedSequenceLimitIdCount(t *testing.T) {
 		t.Errorf("Expected quantity %d, got %d", SEQUENCE_CAP, len(ids))
 	}
 
-	_, err = s.generateId(timestamp)
+	id, err := s.generateId(timestamp)
 	if err == nil {
 		t.Errorf("Expected to throw error when exceeding sequence max")
+	}
+	if id != nil {
+		t.Errorf("Expect ID to be nil")
 	}
 }
 

--- a/snowid_test.go
+++ b/snowid_test.go
@@ -199,7 +199,12 @@ func TestGenerateExceedSequenceLimitIdCount(t *testing.T) {
 	ids := []*SnowID{}
 	timestamp := time.Now().UnixMilli()
 	for range SEQUENCE_CAP {
-		id, _ := s.generateId(timestamp)
+		id, err := s.generateId(timestamp)
+		if err != nil {
+			t.Errorf("Failed to generate ID: %s", err.Error())
+			return
+		}
+
 		ids = append(ids, id)
 	}
 	if len(ids) != SEQUENCE_CAP {


### PR DESCRIPTION
Changes include:
- Add int64 method to the return type.
- Fix bugs in greater than 2065 sequence number.
- Fix test cases bugs.